### PR TITLE
Add support for other PowerPC platforms

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -47,10 +47,16 @@ ifeq ($(platform), unix)
    fpic := -fPIC
    SHARED := -shared -Wl,-no-undefined -Wl,--version-script=$(LIBRETRO_DIR)/link.T
 	PLATFORM_DEFINES := -DUSE_FILE32API
+   ifeq ($(shell uname -m),ppc)
+      ENDIANNESS_DEFINES := -DMSB_FIRST
+   endif
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC
    SHARED := -dynamiclib
+   ifeq ($(shell uname -p),powerpc)
+      ENDIANNESS_DEFINES := -DMSB_FIRST
+   endif
 else ifneq (,$(findstring ios,$(platform)))
    TARGET := $(TARGET_NAME)_libretro_ios.dylib
    fpic := -fPIC


### PR DESCRIPTION
This should make the core work on some other PowerPC platforms. I tried it with Puzzle Fighter on an eMac G4 running Linux and it got basically full speed; although the sound was pretty awful. Not sure what the cause there is, but the main thing is that it works! Haven't been able to try other setups. Merge if you like, I'm not too worried about this so I won't take offense.