### PR TITLE
Add optional low pass audio filter

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -152,6 +152,48 @@ static void init_frameskip(void)
    update_audio_latency = true;
 }
 
+/* Low pass audio filter */
+
+static bool low_pass_enabled       = false;
+static int32_t low_pass_range      = 0;
+/* Previous samples */
+static int32_t low_pass_left_prev  = 0;
+static int32_t low_pass_right_prev = 0;
+
+static void low_pass_filter_stereo(int16_t *buf, int length)
+{
+   int samples            = length;
+   int16_t *out           = buf;
+
+   /* Restore previous samples */
+   int32_t low_pass_left  = low_pass_left_prev;
+   int32_t low_pass_right = low_pass_right_prev;
+
+   /* Single-pole low-pass filter (6 dB/octave) */
+   int32_t factor_a       = low_pass_range;
+   int32_t factor_b       = 0x10000 - factor_a;
+
+   do
+   {
+      /* Apply low-pass filter */
+      low_pass_left  = (low_pass_left  * factor_a) + (*out       * factor_b);
+      low_pass_right = (low_pass_right * factor_a) + (*(out + 1) * factor_b);
+
+      /* 16.16 fixed point */
+      low_pass_left  >>= 16;
+      low_pass_right >>= 16;
+
+      /* Update sound buffer */
+      *out++ = (int16_t)low_pass_left;
+      *out++ = (int16_t)low_pass_right;
+   }
+   while (--samples);
+
+   /* Save last samples for next frame */
+   low_pass_left_prev  = low_pass_left;
+   low_pass_right_prev = low_pass_right;
+}
+
 // FBA stubs
 unsigned ArcadeJoystick;
 
@@ -454,6 +496,11 @@ void retro_init()
    retro_audio_buff_underrun  = false;
    audio_latency              = 0;
    update_audio_latency       = false;
+
+   low_pass_enabled           = false;
+   low_pass_range             = 0;
+   low_pass_left_prev         = 0;
+   low_pass_right_prev        = 0;
 }
 
 void retro_deinit(void)
@@ -490,6 +537,9 @@ void retro_reset(void)
    nCurrentFrame++;
    HiscoreApply();
    Cps2Frame();
+
+   low_pass_left_prev  = 0;
+   low_pass_right_prev = 0;
 }
 
 static bool first_init = true;
@@ -544,6 +594,21 @@ static void check_variables(bool first_run)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       if (strcmp(var.value, "arcade") == 0)
          gamepad_controls = false;
+
+   var.key             = "fba2012cps2_lowpass_filter";
+   var.value           = NULL;
+   low_pass_enabled    = false;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+      if (strcmp(var.value, "enabled") == 0)
+         low_pass_enabled = true;
+
+   var.key             = "fba2012cps2_lowpass_range";
+   var.value           = NULL;
+   low_pass_range      = (60 * 65536) / 100;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+      low_pass_range = (strtol(var.value, NULL, 10) * 65536) / 100;
 
    var.key             = "fba2012cps2_frameskip";
    var.value           = NULL;
@@ -645,6 +710,9 @@ void retro_run(void)
       video_cb(g_fba_frame, width, height, nBurnPitch);
    else
       video_cb(NULL, width, height, nBurnPitch);
+
+   if (low_pass_enabled)
+      low_pass_filter_stereo(g_audio_buf, nBurnSoundLen);
 
    audio_batch_cb(g_audio_buf, nBurnSoundLen);
 

--- a/src/burner/libretro/libretro_core_options.h
+++ b/src/burner/libretro/libretro_core_options.h
@@ -92,6 +92,45 @@ struct retro_core_option_definition option_defs_us[] = {
       "gamepad"
    },
    {
+      "fba2012cps2_lowpass_filter",
+      "Audio Filter",
+      "Enables a low pass audio filter to soften the 'harsh' sound of some arcade games.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "fba2012cps2_lowpass_range",
+      "Audio Filter Level (%)",
+      "Specifies the cut-off frequency of the low pass audio filter. A higher value increases the perceived 'strength' of the filter, since a wider range of the high frequency spectrum is attenuated.",
+      {
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { "35", NULL },
+         { "40", NULL },
+         { "45", NULL },
+         { "50", NULL },
+         { "55", NULL },
+         { "60", NULL },
+         { "65", NULL },
+         { "70", NULL },
+         { "75", NULL },
+         { "80", NULL },
+         { "85", NULL },
+         { "90", NULL },
+         { "95", NULL },
+         { NULL, NULL },
+      },
+      "60"
+   },
+   {
       "fba2012cps2_frameskip",
       "Frameskip",
       "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Manual' utilises the 'Frameskip Threshold (%)' setting.",


### PR DESCRIPTION
Arcade content has a tendency to sound harsh/abrasive, in part due to the prevalence of low quality audio samples. This PR seeks to mitigate the issue by adding an optional (and fast) low pass audio filter. This is enabled via a new `Audio Filter` core option, and the filter 'strength' can be set via `Audio Filter Level (%)`.

This makes many games sound far more pleasant, and has a negligible performance impact.