### PR TITLE
Add aspect ratio correction + display rotation improvements

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -288,7 +288,7 @@ else ifeq ($(platform), gcw0)
    fpic := -fPIC
    SHARED := -shared -Wl,--gc-sections -Wl,-no-undefined -Wl,--version-script=$(LIBRETRO_DIR)/link.T
    LDFLAGS += $(PTHREAD_FLAGS)
-   CFLAGS += $(PTHREAD_FLAGS) -DHAVE_MKDIR
+   CFLAGS += $(PTHREAD_FLAGS) -DHAVE_MKDIR -DDINGUX
    CFLAGS += -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
    CFLAGS +=  -fomit-frame-pointer -ffunction-sections -fdata-sections
    CXXFLAGS += -std=gnu++11 $(CFLAGS)

--- a/src/burn/burn.c
+++ b/src/burn/burn.c
@@ -462,6 +462,19 @@ INT32 BurnDrvGetVisibleSize(INT32* pnWidth, INT32* pnHeight)
 	return 0;
 }
 
+INT32 BurnDrvGetFullSize(INT32* pnWidth, INT32* pnHeight)
+{
+	if (pDriver[nBurnDrvActive]->Flags & BDF_ORIENTATION_VERTICAL) {
+		*pnWidth =pDriver[nBurnDrvActive]->nHeight;
+		*pnHeight=pDriver[nBurnDrvActive]->nWidth;
+	} else {
+		*pnWidth =pDriver[nBurnDrvActive]->nWidth;
+		*pnHeight=pDriver[nBurnDrvActive]->nHeight;
+	}
+
+	return 0;
+}
+
 // Get the hardware code
 INT32 BurnDrvGetHardwareCode(void)
 {

--- a/src/burn/burn.h
+++ b/src/burn/burn.h
@@ -273,6 +273,7 @@ INT32 BurnDrvGetRomName(char** pszName, UINT32 i, INT32 nAka);
 INT32 BurnDrvGetInputInfo(struct BurnInputInfo* pii, UINT32 i);
 INT32 BurnDrvGetDIPInfo(struct BurnDIPInfo* pdi, UINT32 i);
 INT32 BurnDrvGetVisibleSize(INT32* pnWidth, INT32* pnHeight);
+INT32 BurnDrvGetFullSize(INT32* pnWidth, INT32* pnHeight);
 INT32 BurnDrvGetHardwareCode();
 INT32 BurnDrvGetFlags();
 BOOL BurnDrvIsWorking();

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -46,8 +46,12 @@ static unsigned g_rom_count;
 #define AUDIO_SEGMENT_LENGTH 534 // <-- Hardcoded value that corresponds well to 32kHz audio.
 #define VIDEO_REFRESH_RATE 59.629403f
 
-static uint16_t *g_fba_frame;
+static uint16_t *g_fba_frame      = NULL;
+static uint16_t *g_fba_rotate_buf = NULL;
 static int16_t g_audio_buf[AUDIO_SEGMENT_LENGTH * 2];
+
+static uint16_t rotate_buf_width  = 0;
+static uint16_t rotate_buf_margin = 0;
 
 // libretro globals
 
@@ -73,7 +77,12 @@ void retro_set_environment(retro_environment_t cb)
 char g_rom_dir[1024];
 char g_save_dir[1024];
 char g_system_dir[1024];
-static bool driver_inited;
+static bool driver_inited       = false;
+static bool core_aspect_par     = false;
+static bool display_auto_rotate = true;
+static bool display_rotated     = false;
+static bool hw_rotate_enabled   = false;
+static bool input_rotated       = false;
 
 void retro_get_system_info(struct retro_system_info *info)
 {
@@ -231,7 +240,6 @@ UINT8* CDEmuReadQChannel() { return 0; }
 INT32 CDEmuGetSoundBuffer(INT16* buffer, INT32 samples) { return 0; }
 #endif
 
-static unsigned char nPrevDIPSettings[4];
 static int nDIPOffset;
 
 static void InpDIPSWGetOffset (void)
@@ -275,12 +283,11 @@ void InpDIPSWResetDIPs (void)
 static int InpDIPSWInit()
 {
    BurnDIPInfo bdi;
-   struct GameInp *pgi;
 
    InpDIPSWGetOffset();
    InpDIPSWResetDIPs();
 
-   for(int i = 0, j = 0; BurnDrvGetDIPInfo(&bdi, i) == 0; i++)
+   for(int i = 0; BurnDrvGetDIPInfo(&bdi, i) == 0; i++)
    {
       /* 0xFE is the beginning label for a DIP switch entry */
       /* 0xFD are region DIP switches */
@@ -303,9 +310,6 @@ static int InpDIPSWInit()
                log_cb(RETRO_LOG_INFO, "DIP switch option: %s.\n", bdi_tmp.szText);
             l++;
          }
-         pgi = GameInp + bdi.nInput + nDIPOffset;
-         nPrevDIPSettings[j] = pgi->Input.Constant.nConst;
-         j++;
       }
    }
 
@@ -485,8 +489,8 @@ void retro_init()
       log_cb = log.log;
    else
       log_cb = NULL;
+
    BurnLibInit();
-   g_fba_frame = (uint16_t*)malloc(384 * 224 * sizeof(uint16_t));
 
    frameskip_type             = 0;
    frameskip_threshold        = 0;
@@ -505,9 +509,16 @@ void retro_init()
 
 void retro_deinit(void)
 {
+   GameInpExit();
    BurnLibExit();
+
    if (g_fba_frame)
       free(g_fba_frame);
+   g_fba_frame = NULL;
+
+   if (g_fba_rotate_buf)
+      free(g_fba_rotate_buf);
+   g_fba_rotate_buf = NULL;
 }
 
 extern "C" {
@@ -547,6 +558,7 @@ static bool first_init = true;
 static void check_variables(bool first_run)
 {
    struct retro_variable var = {0};
+   bool last_core_aspect_par;
    unsigned last_frameskip_type;
 
    var.key             = "fba2012cps2_cpu_speed_adjust";
@@ -595,6 +607,33 @@ static void check_variables(bool first_run)
       if (strcmp(var.value, "arcade") == 0)
          gamepad_controls = false;
 
+   var.key              = "fba2012cps2_aspect";
+   var.value            = NULL;
+   last_core_aspect_par = core_aspect_par;
+   core_aspect_par      = false;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+      if (strcmp(var.value, "PAR") == 0)
+         core_aspect_par = true;
+
+   if (!first_run && (core_aspect_par != last_core_aspect_par))
+   {
+      struct retro_system_av_info av_info;
+      retro_get_system_av_info(&av_info);
+      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
+   }
+
+   if (first_run)
+   {
+      var.key             = "fba2012cps2_auto_rotate";
+      var.value           = NULL;
+      display_auto_rotate = true;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+         if (strcmp(var.value, "disabled") == 0)
+            display_auto_rotate = false;
+   }
+
    var.key             = "fba2012cps2_lowpass_filter";
    var.value           = NULL;
    low_pass_enabled    = false;
@@ -638,8 +677,9 @@ static void check_variables(bool first_run)
 void retro_run(void)
 {
    INT32 width, height;
-   BurnDrvGetVisibleSize(&width, &height);
+   BurnDrvGetFullSize(&width, &height);
    pBurnDraw = (uint8_t*)g_fba_frame;
+   nBurnPitch = width * sizeof(uint16_t);
    nSkipFrame = 0;
 
    poll_input();
@@ -648,26 +688,6 @@ void retro_run(void)
    pBurnSoundOut = g_audio_buf;
    nBurnSoundRate = AUDIO_SAMPLERATE;
    //nBurnSoundLen = AUDIO_SEGMENT_LENGTH;
-
-   unsigned drv_flags = BurnDrvGetFlags();
-   uint32_t height_tmp = height;
-   size_t pitch_size = sizeof(uint16_t);
-
-   switch (drv_flags & (BDF_ORIENTATION_FLIPPED | BDF_ORIENTATION_VERTICAL))
-   {
-      case BDF_ORIENTATION_VERTICAL:
-      case BDF_ORIENTATION_VERTICAL | BDF_ORIENTATION_FLIPPED:
-         nBurnPitch = height * pitch_size;
-         height = width;
-         width = height_tmp;
-         break;
-      case BDF_ORIENTATION_FLIPPED:
-      default:
-         nBurnPitch = width * pitch_size;
-   }
-
-   nCurrentFrame++;
-   HiscoreApply();
 
    /* Check whether current frame should
     * be skipped */
@@ -704,12 +724,36 @@ void retro_run(void)
       update_audio_latency = false;
    }
 
+   nCurrentFrame++;
+   HiscoreApply();
    Cps2Frame();
 
-   if (!nSkipFrame)
-      video_cb(g_fba_frame, width, height, nBurnPitch);
+   if (!display_rotated || hw_rotate_enabled)
+   {
+      if (!nSkipFrame)
+         video_cb(g_fba_frame, width, height, nBurnPitch);
+      else
+         video_cb(NULL, width, height, nBurnPitch);
+   }
    else
-      video_cb(NULL, width, height, nBurnPitch);
+   {
+      /* Perform software-based display rotation */
+      if (!nSkipFrame)
+      {
+         uint16_t *in_ptr  = g_fba_frame;
+         uint16_t *out_ptr = g_fba_rotate_buf;
+         size_t x, y;
+
+         for (y = 0; y < height; y++)
+            for (x = 0; x < width; x++)
+               *(out_ptr + (y + rotate_buf_margin) + (((width - 1) - x) * rotate_buf_width)) =
+                     *(in_ptr + x + (y * width));
+
+         video_cb(g_fba_rotate_buf, rotate_buf_width, width, rotate_buf_width * sizeof(uint16_t));
+      }
+      else
+         video_cb(NULL, rotate_buf_width, width, rotate_buf_width * sizeof(uint16_t));
+   }
 
    if (low_pass_enabled)
       low_pass_filter_stereo(g_audio_buf, nBurnSoundLen);
@@ -785,13 +829,49 @@ void retro_cheat_set(unsigned, bool, const char*) {}
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
    INT32 width, height;
-   BurnDrvGetVisibleSize(&width, &height);
-   unsigned maximum = width > height ? width : height;
-   struct retro_game_geometry geom = { (unsigned)width, (unsigned)height, maximum, maximum };
-   struct retro_system_timing timing = { VIDEO_REFRESH_RATE, VIDEO_REFRESH_RATE * AUDIO_SEGMENT_LENGTH };
 
-   info->geometry = geom;
-   info->timing   = timing;
+   memset(info, 0, sizeof(*info));
+
+   BurnDrvGetVisibleSize(&width, &height);
+
+   if (display_rotated && !hw_rotate_enabled)
+   {
+      info->geometry.base_width   = (unsigned)rotate_buf_width;
+      info->geometry.base_height  = (unsigned)height;
+      info->geometry.max_width    = (unsigned)rotate_buf_width;
+      info->geometry.max_height   = (unsigned)height;
+   }
+   else
+   {
+      unsigned drv_flags = BurnDrvGetFlags();
+
+      if (!display_auto_rotate &&
+          (drv_flags & BDF_ORIENTATION_VERTICAL))
+      {
+         info->geometry.base_width   = (unsigned)height;
+         info->geometry.base_height  = (unsigned)width;
+         info->geometry.max_width    = (unsigned)height;
+         info->geometry.max_height   = (unsigned)width;
+      }
+      else
+      {
+         info->geometry.base_width   = (unsigned)width;
+         info->geometry.base_height  = (unsigned)height;
+         info->geometry.max_width    = (unsigned)width;
+         info->geometry.max_height   = (unsigned)height;
+      }
+   }
+
+   if (!core_aspect_par)
+#if defined(DINGUX)
+      info->geometry.aspect_ratio = (4.0f / 3.0f);
+#else
+      info->geometry.aspect_ratio = display_rotated ?
+            (3.0f / 4.0f) : (4.0f / 3.0f);
+#endif
+
+   info->timing.fps               = VIDEO_REFRESH_RATE;
+   info->timing.sample_rate       = VIDEO_REFRESH_RATE * AUDIO_SEGMENT_LENGTH;
 }
 
 int VidRecalcPal()
@@ -802,7 +882,7 @@ int VidRecalcPal()
 static bool fba_init(unsigned driver, const char *game_zip_name)
 {
    nBurnDrvActive = driver;
-   char input[128];
+   char input_fs[1024];
 
    if (!open_archive())
       return false;
@@ -812,49 +892,70 @@ static bool fba_init(unsigned driver, const char *game_zip_name)
    nInterpolation = 3;
 
    BurnDrvInit();
-   snprintf (input, sizeof(input), "%s%c%s.fs", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
-   BurnStateLoad(input, 0, NULL);
-
-   INT32 width, height;
-   BurnDrvGetVisibleSize(&width, &height);
-   unsigned drv_flags = BurnDrvGetFlags();
-   size_t pitch_size = nBurnBpp == 2 ? sizeof(uint16_t) : sizeof(uint32_t);
-   if (drv_flags & BDF_ORIENTATION_VERTICAL)
-      nBurnPitch = height * pitch_size;
-   else
-      nBurnPitch = width * pitch_size;
-
-   unsigned rotation;
-   switch (drv_flags & (BDF_ORIENTATION_FLIPPED | BDF_ORIENTATION_VERTICAL))
-   {
-      case BDF_ORIENTATION_VERTICAL:
-         rotation = 1;
-         break;
-
-      case BDF_ORIENTATION_FLIPPED:
-         rotation = 2;
-         break;
-
-      case BDF_ORIENTATION_VERTICAL | BDF_ORIENTATION_FLIPPED:
-         rotation = 3;
-         break;
-
-      default:
-         rotation = 0;
-   }
+   snprintf(input_fs, sizeof(input_fs), "%s%c%s.fs", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
+   BurnStateLoad(input_fs, 0, NULL);
 
    if (log_cb)
       log_cb(RETRO_LOG_INFO, "Game: %s\n", game_zip_name);
 
-   environ_cb(RETRO_ENVIRONMENT_SET_ROTATION, &rotation);
+   INT32 width, height;
+   BurnDrvGetFullSize(&width, &height);
+   nBurnPitch = width * sizeof(uint16_t);
+
+   unsigned drv_flags = BurnDrvGetFlags();
+
+   if (display_auto_rotate)
+   {
+      display_rotated = (drv_flags & BDF_ORIENTATION_VERTICAL);
+      input_rotated   = false;
+   }
+   else
+   {
+      display_rotated = false;
+      input_rotated   = (drv_flags & BDF_ORIENTATION_VERTICAL);
+   }
+
+   if (display_rotated)
+   {
+      unsigned rotation = 1;
+      hw_rotate_enabled = environ_cb(RETRO_ENVIRONMENT_SET_ROTATION, &rotation);
+
+      if (!hw_rotate_enabled)
+      {
+         uint16_t rotate_buf_height = (uint16_t)width;
+#if defined(DINGUX)
+         /* OpenDingux platforms do not have proper
+          * aspect ratio control - we can only select
+          * between PAR and 'fullscreen stretched'.
+          * Since vertical CPS games are meant to be
+          * displayed at a ratio of 3:4, either option
+          * produces severe visual distortion. We work
+          * around this by padding the rotated image, so
+          * the resultant rotation buffer is 'square'
+          * (this gives the correct 4:3 ratio when
+          * stretched to fit the screen)
+          * > Note: on OpenDingux, always round video
+          *   width up to the nearest multiple of 16 */
+         rotate_buf_width  = (rotate_buf_height + 0xF) & ~0xF;
+         rotate_buf_margin = (rotate_buf_width - height) >> 1;
+#else
+         rotate_buf_width  = height;
+         rotate_buf_margin = 0;
+#endif
+         g_fba_rotate_buf = (uint16_t*)calloc(1,
+               (uint32_t)rotate_buf_width * (uint32_t)rotate_buf_height * sizeof(uint16_t));
+      }
+   }
 
    VidRecalcPal();
 
+#ifdef FRONTEND_SUPPORTS_RGB565
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_RGB565;
 
    if(environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
       if (log_cb)
          log_cb(RETRO_LOG_INFO, "Frontend supports RGB565 - will use that instead of XRGB1555.\n");
+#endif
 
    return true;
 }
@@ -941,6 +1042,8 @@ bool retro_load_game(const struct retro_game_info *info)
    unsigned i = BurnDrvGetIndexByName(basename);
    if (i < nBurnDrvCount)
    {
+      INT32 width, height;
+
       pBurnSoundOut = g_audio_buf;
       nBurnSoundRate = AUDIO_SAMPLERATE;
       nBurnSoundLen = AUDIO_SEGMENT_LENGTH;
@@ -952,6 +1055,9 @@ bool retro_load_game(const struct retro_game_info *info)
 
       driver_inited = true;
       analog_controls_enabled = init_input();
+
+      BurnDrvGetFullSize(&width, &height);
+      g_fba_frame = (uint16_t*)malloc(width * height * sizeof(uint16_t));
 
       retval = true;
    }
@@ -965,14 +1071,17 @@ bool retro_load_game(const struct retro_game_info *info)
 
 bool retro_load_game_special(unsigned, const struct retro_game_info*, size_t) { return false; }
 
-void retro_unload_game(void) {
-   char output[128];
+void retro_unload_game(void)
+{
    if (driver_inited)
    {
-      snprintf (output,sizeof(output), "%s%c%s.fs", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
-      BurnStateSave(output, 0);
+      char output_fs[1024];
+
+      snprintf(output_fs, sizeof(output_fs), "%s%c%s.fs", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
+      BurnStateSave(output_fs, 0);
       BurnDrvExit();
    }
+
    driver_inited = false;
 }
 
@@ -1187,117 +1296,117 @@ static bool init_input(void)
    /* Movement controls */
 
    bind_map[PTR_INCR].bii_name = "Up";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "Down";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "Left";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "Right";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "Up (Cocktail)";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "Down (Cocktail)";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "Left (Cocktail)";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "Right (Cocktail)";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Up";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Down";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Left";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Right";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P2 Up";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P2 Down";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P2 Left";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P2 Right";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P3 Up";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P3 Down";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P3 Left";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P3 Right";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P4 Up";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 3;
 
    bind_map[PTR_INCR].bii_name = "P4 Down";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 3;
 
    bind_map[PTR_INCR].bii_name = "P4 Left";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 3;
 
    bind_map[PTR_INCR].bii_name = "P4 Right";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 3;
 
    /* Angel Kids, Crazy Climber 2, Bullet, etc. */
 
    bind_map[PTR_INCR].bii_name = "P1 Left Stick Up";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Left Stick Down";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Left Stick Left";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Left Stick Right";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Right Stick Up";
@@ -1333,19 +1442,19 @@ static bool init_input(void)
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Up 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Down 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Left 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Right 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P1 Up 2";
@@ -1365,19 +1474,19 @@ static bool init_input(void)
    bind_map[PTR_INCR].nCode[1] = 0;
 
    bind_map[PTR_INCR].bii_name = "P2 Up 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P2 Down 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P2 Left 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P2 Right 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P2 Up 2";
@@ -1397,19 +1506,19 @@ static bool init_input(void)
    bind_map[PTR_INCR].nCode[1] = 1;
 
    bind_map[PTR_INCR].bii_name = "P3 Up 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_UP;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_RIGHT : RETRO_DEVICE_ID_JOYPAD_UP;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P3 Down 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_DOWN;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_LEFT : RETRO_DEVICE_ID_JOYPAD_DOWN;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P3 Left 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_LEFT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_UP : RETRO_DEVICE_ID_JOYPAD_LEFT;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P3 Right 1";
-   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_RIGHT;
+   bind_map[PTR_INCR].nCode[0] = input_rotated ? RETRO_DEVICE_ID_JOYPAD_DOWN : RETRO_DEVICE_ID_JOYPAD_RIGHT;
    bind_map[PTR_INCR].nCode[1] = 2;
 
    bind_map[PTR_INCR].bii_name = "P3 Up 2";

--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -1057,7 +1057,7 @@ bool retro_load_game(const struct retro_game_info *info)
       analog_controls_enabled = init_input();
 
       BurnDrvGetFullSize(&width, &height);
-      g_fba_frame = (uint16_t*)malloc(width * height * sizeof(uint16_t));
+      g_fba_frame = (uint16_t*)malloc((uint32_t)width * (uint32_t)height * sizeof(uint16_t));
 
       retval = true;
    }

--- a/src/burner/libretro/libretro_core_options.h
+++ b/src/burner/libretro/libretro_core_options.h
@@ -92,6 +92,28 @@ struct retro_core_option_definition option_defs_us[] = {
       "gamepad"
    },
    {
+      "fba2012cps2_aspect",
+      "Core-Provided Aspect Ratio",
+      "Selects the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
+      {
+         { "DAR", NULL },
+         { "PAR", NULL },
+         { NULL, NULL },
+      },
+      "DAR"
+   },
+   {
+      "fba2012cps2_auto_rotate",
+      "Rotate Vertically Aligned Games (Restart)",
+      "Automatically rotate the display when running vertically aligned games. When disabled, D-Pad input will be rotated to match on-screen directions.",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "fba2012cps2_lowpass_filter",
       "Audio Filter",
       "Enables a low pass audio filter to soften the 'harsh' sound of some arcade games.",


### PR DESCRIPTION
This PR makes the following improvements to the core:

- A new `Core-Provided Aspect Ratio` option has been added. This can be set to `DAR` or `PAR`. When `DAR` is selected, the core outputs content at a ratio of 4:3 (or 3:4 for vertical games). Previously, the core always used `PAR` (resulting in stretched graphics)

- At present, the core uses gfx driver hardware-based rotation to display vertical games with the correct orientation. For platforms without hardware rotation support, this is clearly inadequate. This PR adds a new software-based fallback, so rotation now works on all devices. (It is quite slow, however...)

- A new `Rotate Vertically Aligned Games (Restart)` option has been added. When enabled (by default), vertical games are always rotated. When disabled, they are displayed in landscape orientation - and d-pad inputs are automatically rotated to match the on-screen directions. This makes vertical games highly playable on devices that are too slow for software-based rotation

- A memory leak has been fixed (input wasn't being de-initialised correctly...)

- An out of bounds array write has been fixed

- The size of the file path char arrays used when saving/restoring non-volatile data has been increased (these were previously dangerously small...)
