### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -195,7 +195,7 @@ else ifeq ($(platform), wiiu)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    ENDIANNESS_DEFINES = -DMSB_FIRST
    PLATFORM_DEFINES := -DGEKKO -DWIIU -DHW_RVL -mcpu=750 -meabi -mhard-float
-   PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+   PLATFORM_DEFINES += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
    EXTERNAL_ZLIB = 1
 	STATIC_LINKING = 1
 else ifeq ($(platform), ctr)


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)